### PR TITLE
Avoid clone()s & copies in rust-hyper

### DIFF
--- a/rust-hyper/Cargo.lock
+++ b/rust-hyper/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "macros",
  "ramp",
  "rand 0.5.6",
+ "serde",
  "serde_json",
 ]
 

--- a/rust-hyper/backend/src/main.rs
+++ b/rust-hyper/backend/src/main.rs
@@ -10,7 +10,7 @@ use std::{convert::Infallible, net::SocketAddr};
 
 use execution_engine::{self, eval, expr::*, ivec, runtime};
 
-fn fizzboom() -> Expr {
+fn fizzboom<'a>() -> Expr<'a> {
   elet("range",
        esfn("Int", "range", 0, ivec![eint(1), eint(100),]),
        esfn("List",
@@ -53,7 +53,7 @@ fn fizzboom() -> Expr {
                                            0,
                                            ivec![evar("i")])))))]))
 }
-fn fizzbuzz() -> Expr {
+fn fizzbuzz<'a>() -> Expr<'a> {
   elet("range",
        esfn("Int", "range", 0, ivec![eint(1), eint(100),]),
        esfn("List",
@@ -97,13 +97,13 @@ fn fizzbuzz() -> Expr {
                                            ivec![evar("i")])))))]))
 }
 
-async fn run_program(program: Expr)
+async fn run_program<'a>(program: Expr<'a>)
                      -> String {
   let tlid = runtime::TLID::TLID(7);
   let state =
     eval::ExecState { caller: runtime::Caller::Toplevel(tlid), };
-  let result = eval::run_json(&state, program);
-  result.to_string()
+  
+  eval::run_json(&state, program)
 }
 
 async fn handle(req: Request<Body>)
@@ -112,7 +112,9 @@ async fn handle(req: Request<Body>)
 
   match (req.method(), req.uri().path()) {
       (&Method::GET, "/fizzbuzz") => {
-          *response.body_mut() = Body::from(run_program(fizzbuzz()).await);
+        let r = fizzbuzz();
+        let f = run_program(r).await;
+          *response.body_mut() = Body::from(f);
       },
       (&Method::GET, "/fizzboom") => {
           *response.body_mut() = Body::from(run_program(fizzboom()).await);

--- a/rust-hyper/backend/src/main.rs
+++ b/rust-hyper/backend/src/main.rs
@@ -8,16 +8,16 @@ use hyper::{
 };
 use std::{convert::Infallible, net::SocketAddr};
 
-use execution_engine::{self, eval, expr::*, ivec, runtime};
+use execution_engine::{self, eval, expr::*, runtime};
 
 fn fizzboom<'a>() -> Expr<'a> {
   elet("range",
-       esfn("Int", "range", 0, ivec![eint(1), eint(100),]),
+       esfn("Int", "range", 0, vec![eint(1), eint(100),].into()),
        esfn("List",
             "map",
             0,
-            ivec![(evar("range")),
-                  elambda(ivec!["i"],
+            vec![(evar("range")),
+                  elambda(vec!["i"].into(),
                           eif(ebinop(ebinop(evar("i"),
                                             "Int",
                                             "%",
@@ -27,7 +27,7 @@ fn fizzboom<'a>() -> Expr<'a> {
                                      "==",
                                      0,
                                      eint(0)),
-                              esfn("HTTPClient", "get", 0, ivec![estr("http://localhost:1025/delay/1")]),
+                              esfn("HTTPClient", "get", 0, vec![estr("http://localhost:1025/delay/1")].into()),
                               eif(ebinop(ebinop(evar("i"),
                                                 "Int",
                                                 "%",
@@ -51,16 +51,16 @@ fn fizzboom<'a>() -> Expr<'a> {
                                       esfn("Int",
                                            "toString",
                                            0,
-                                           ivec![evar("i")])))))]))
+                                           vec![evar("i")].into())))))].into()))
 }
 fn fizzbuzz<'a>() -> Expr<'a> {
   elet("range",
-       esfn("Int", "range", 0, ivec![eint(1), eint(100),]),
+       esfn("Int", "range", 0, vec![eint(1), eint(100),].into()),
        esfn("List",
             "map",
             0,
-            ivec![(evar("range")),
-                  elambda(ivec!["i"],
+            vec![(evar("range")),
+                  elambda(vec!["i"].into(),
                           eif(ebinop(ebinop(evar("i"),
                                             "Int",
                                             "%",
@@ -94,7 +94,7 @@ fn fizzbuzz<'a>() -> Expr<'a> {
                                       esfn("Int",
                                            "toString",
                                            0,
-                                           ivec![evar("i")])))))]))
+                                           vec![evar("i")].into())))))].into()))
 }
 
 async fn run_program<'a>(program: Expr<'a>)

--- a/rust-hyper/backend/src/main.rs
+++ b/rust-hyper/backend/src/main.rs
@@ -97,7 +97,7 @@ fn fizzbuzz<'a>() -> Expr<'a> {
                                            vec![evar("i")].into())))))].into()))
 }
 
-async fn run_program<'a>(program: Expr<'a>)
+async fn run_program<'a>(program: &'a Expr<'a>)
                      -> String {
   let tlid = runtime::TLID::TLID(7);
   let state =
@@ -113,11 +113,11 @@ async fn handle(req: Request<Body>)
   match (req.method(), req.uri().path()) {
       (&Method::GET, "/fizzbuzz") => {
         let r = fizzbuzz();
-        let f = run_program(r).await;
+        let f = run_program(&r).await;
           *response.body_mut() = Body::from(f);
       },
       (&Method::GET, "/fizzboom") => {
-          *response.body_mut() = Body::from(run_program(fizzboom()).await);
+          *response.body_mut() = Body::from(run_program(&fizzboom()).await);
       },
       _ => {
           *response.status_mut() = StatusCode::NOT_FOUND;

--- a/rust-hyper/backend/src/main.rs
+++ b/rust-hyper/backend/src/main.rs
@@ -126,7 +126,7 @@ async fn handle(req: Request<Body>)
   Ok(response)
 }
 
-#[tokio::main]
+#[tokio::main(threaded_scheduler)]
 async fn main() {
   let port = std::fs::read_to_string("port").unwrap()
                                             .trim()

--- a/rust-hyper/execution-engine/Cargo.toml
+++ b/rust-hyper/execution-engine/Cargo.toml
@@ -14,3 +14,4 @@ ramp = "0.5.9"
 macros = { version = "*", path = "../macros"}
 serde_json = "1.0"
 chttp = "0.5.5"
+serde = "1.0"

--- a/rust-hyper/execution-engine/src/dval.rs
+++ b/rust-hyper/execution-engine/src/dval.rs
@@ -1,8 +1,9 @@
 use crate::expr;
 use im_rc as im;
-use std::{fmt, sync::Arc};
+use std::{fmt};
 use std::borrow::Cow;
 use serde::ser::{Serialize, SerializeSeq};
+use std::rc::Rc;
 
 // use crate::{errors, expr};
 use crate::{errors, runtime};
@@ -59,11 +60,11 @@ impl<'a> Dval_<'a> {
   }
 }
 
-pub type Dval<'a> = Arc<Dval_<'a>>;
+pub type Dval<'a> = Rc<Dval_<'a>>;
 
 #[derive(Debug)]
 pub enum DType<'a> {
-  TList(Arc<DType<'a>>),
+  TList(Rc<DType<'a>>),
   TLambda,
   TBool,
   NamedType(&'a str),
@@ -86,34 +87,34 @@ impl<'a> fmt::Display for DType<'a> {
 pub fn derror<'a>(caller: &runtime::Caller,
               error: errors::Error<'a>)
               -> Dval<'a> {
-  Arc::new(Dval_::DSpecial(Special::Error(*caller, error)))
+  Rc::new(Dval_::DSpecial(Special::Error(*caller, error)))
 }
 
 pub fn dcode_error<'a>(caller: &runtime::Caller,
                    id: runtime::ID,
                    error: errors::Error<'a>)
                    -> Dval<'a> {
-  Arc::new(Dval_::DSpecial(Special::Error(
+  Rc::new(Dval_::DSpecial(Special::Error(
         runtime::Caller::Code(caller.to_tlid(), id),
         error,
     )))
 }
 
 pub fn dincomplete<'a>(caller: &runtime::Caller) -> Dval<'a> {
-  Arc::new(Dval_::DSpecial(Special::Incomplete(*caller)))
+  Rc::new(Dval_::DSpecial(Special::Incomplete(*caller)))
 }
 
 pub fn dbool<'a>(val: bool) -> Dval<'a> {
-  Arc::new(Dval_::DBool(val))
+  Rc::new(Dval_::DBool(val))
 }
 pub fn dint<'a>(i: ramp::Int) -> Dval<'a> {
-  Arc::new(Dval_::DInt(i))
+  Rc::new(Dval_::DInt(i))
 }
 
 pub fn dstr<'a>(val: Cow<'a, str>) -> Dval<'a> {
-  Arc::new(Dval_::DStr(val))
+  Rc::new(Dval_::DStr(val))
 }
 
 pub fn dlist<'a>(l: im::Vector<Dval<'a>>) -> Dval<'a> {
-  Arc::new(Dval_::DList(l))
+  Rc::new(Dval_::DList(l))
 }

--- a/rust-hyper/execution-engine/src/dval.rs
+++ b/rust-hyper/execution-engine/src/dval.rs
@@ -21,7 +21,7 @@ pub enum Dval_<'a> {
   DInt(ramp::Int),
   DStr(Cow<'a, str>),
   DList(im::Vector<Dval<'a>>),
-  DLambda(runtime::SymTable<'a>, Cow<'a, [&'a str]>, expr::Expr<'a>),
+  DLambda(runtime::SymTable<'a>, Cow<'a, [&'a str]>, &'a expr::Expr<'a>),
   DSpecial(Special<'a>),
 }
 

--- a/rust-hyper/execution-engine/src/dval.rs
+++ b/rust-hyper/execution-engine/src/dval.rs
@@ -21,7 +21,7 @@ pub enum Dval_<'a> {
   DInt(ramp::Int),
   DStr(Cow<'a, str>),
   DList(im::Vector<Dval<'a>>),
-  DLambda(runtime::SymTable<'a>, im::Vector<&'a str>, expr::Expr<'a>),
+  DLambda(runtime::SymTable<'a>, Cow<'a, [&'a str]>, expr::Expr<'a>),
   DSpecial(Special<'a>),
 }
 

--- a/rust-hyper/execution-engine/src/dval.rs
+++ b/rust-hyper/execution-engine/src/dval.rs
@@ -1,6 +1,8 @@
 use crate::expr;
 use im_rc as im;
 use std::{fmt, sync::Arc};
+use std::borrow::Cow;
+use serde::ser::{Serialize, SerializeSeq};
 
 // use crate::{errors, expr};
 use crate::{errors, runtime};
@@ -8,107 +10,110 @@ use ramp;
 
 // These are types that aren't real values, but are used to hold other information
 #[derive(Debug)]
-pub enum Special {
-  Error(runtime::Caller, errors::Error),
+pub enum Special<'a> {
+  Error(runtime::Caller, errors::Error<'a>),
   Incomplete(runtime::Caller),
 }
 
 #[derive(Debug)]
-pub enum Dval_ {
+pub enum Dval_<'a> {
   DBool(bool),
   DInt(ramp::Int),
-  DStr(String),
-  DList(im::Vector<Dval>),
-  DLambda(runtime::SymTable, im::Vector<String>, expr::Expr),
-  DSpecial(Special),
+  DStr(Cow<'a, str>),
+  DList(im::Vector<Dval<'a>>),
+  DLambda(runtime::SymTable<'a>, im::Vector<&'a str>, expr::Expr<'a>),
+  DSpecial(Special<'a>),
 }
 
-impl Dval_ {
+impl<'a> Serialize for Dval_<'a> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+      use Dval_::*;
+      match self {
+        DBool(v) => serializer.serialize_bool(*v),
+        DInt(i) => {
+          if i.bit_length() > 53 {
+            serializer.serialize_str(&i.to_str_radix(10, false))
+          } else {
+            serializer.serialize_f64(i.to_f64())
+          }
+        },
+        DStr(s) => serializer.serialize_str(&s),
+        DList(lst) => {
+          
+          let mut seq = serializer.serialize_seq(Some(lst.len()))?;
+
+          for elem in lst {
+            seq.serialize_element(&**elem)?;
+          }
+
+          seq.end()
+        },
+        DLambda(..) | DSpecial(..) => serializer.serialize_none(),
+      }
+    }
+}
+
+impl<'a> Dval_<'a> {
   pub fn is_special(&self) -> bool {
     matches!(self, Dval_::DSpecial(_))
   }
-
-  pub fn to_json(&self) -> serde_json::Value {
-    match self {
-      Dval_::DBool(bool) => serde_json::Value::Bool(*bool),
-      Dval_::DInt(i) => {
-        if i.bit_length() > 53 {
-          serde_json::Value::String(i.to_str_radix(10, false))
-        } else {
-          serde_json::Value::Number(serde_json::Number::from_f64(i.to_f64()).unwrap())
-        }
-      }
-      Dval_::DStr(str) => serde_json::Value::String(str.clone()),
-      Dval_::DList(l) => {
-        serde_json::Value::Array(l.iter()
-                                  .map(|dv| dv.to_json())
-                                  .collect())
-      }
-
-      Dval_::DLambda(_, _, _) => serde_json::Value::Null,
-      Dval_::DSpecial(_) => serde_json::Value::Null,
-    }
-  }
 }
 
-pub type Dval = Arc<Dval_>;
-
-unsafe impl Send for Dval_ {}
-unsafe impl Sync for Dval_ {}
+pub type Dval<'a> = Arc<Dval_<'a>>;
 
 #[derive(Debug)]
-pub enum DType {
-  TList(Arc<DType>),
+pub enum DType<'a> {
+  TList(Arc<DType<'a>>),
   TLambda,
   TBool,
-  NamedType(String),
+  NamedType(&'a str),
 }
 
-impl fmt::Display for Dval_ {
+impl<'a> fmt::Display for Dval_<'a> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.write_fmt(format_args!("{:?}", self))?;
     Ok(())
   }
 }
 
-impl fmt::Display for DType {
+impl<'a> fmt::Display for DType<'a> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.write_fmt(format_args!("{:?}", self))?;
     Ok(())
   }
 }
 
-pub fn derror(caller: &runtime::Caller,
-              error: errors::Error)
-              -> Dval {
+pub fn derror<'a>(caller: &runtime::Caller,
+              error: errors::Error<'a>)
+              -> Dval<'a> {
   Arc::new(Dval_::DSpecial(Special::Error(*caller, error)))
 }
 
-pub fn dcode_error(caller: &runtime::Caller,
+pub fn dcode_error<'a>(caller: &runtime::Caller,
                    id: runtime::ID,
-                   error: errors::Error)
-                   -> Dval {
+                   error: errors::Error<'a>)
+                   -> Dval<'a> {
   Arc::new(Dval_::DSpecial(Special::Error(
         runtime::Caller::Code(caller.to_tlid(), id),
         error,
     )))
 }
 
-pub fn dincomplete(caller: &runtime::Caller) -> Dval {
+pub fn dincomplete<'a>(caller: &runtime::Caller) -> Dval<'a> {
   Arc::new(Dval_::DSpecial(Special::Incomplete(*caller)))
 }
 
-pub fn dbool(val: bool) -> Dval {
+pub fn dbool<'a>(val: bool) -> Dval<'a> {
   Arc::new(Dval_::DBool(val))
 }
-pub fn dint(i: ramp::Int) -> Dval {
+pub fn dint<'a>(i: ramp::Int) -> Dval<'a> {
   Arc::new(Dval_::DInt(i))
 }
 
-pub fn dstr(val: &str) -> Dval {
-  Arc::new(Dval_::DStr(val.to_string()))
+pub fn dstr<'a>(val: Cow<'a, str>) -> Dval<'a> {
+  Arc::new(Dval_::DStr(val))
 }
 
-pub fn dlist(l: im::Vector<Dval>) -> Dval {
+pub fn dlist<'a>(l: im::Vector<Dval<'a>>) -> Dval<'a> {
   Arc::new(Dval_::DList(l))
 }

--- a/rust-hyper/execution-engine/src/errors.rs
+++ b/rust-hyper/execution-engine/src/errors.rs
@@ -6,8 +6,8 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum Error<'a> {
-  MissingFunction(runtime::FunctionDesc_),
-  IncorrectArguments(runtime::FunctionDesc_, Vec<Dval<'a>>),
+  MissingFunction(runtime::FunctionDesc_<'a>),
+  IncorrectArguments(&'a runtime::FunctionDesc_<'a>, Vec<Dval<'a>>),
   InvalidType(Dval<'a>, DType<'a>),
 }
 

--- a/rust-hyper/execution-engine/src/errors.rs
+++ b/rust-hyper/execution-engine/src/errors.rs
@@ -5,13 +5,13 @@ use crate::{
 use std::fmt;
 
 #[derive(Debug)]
-pub enum Error {
+pub enum Error<'a> {
   MissingFunction(runtime::FunctionDesc_),
-  IncorrectArguments(runtime::FunctionDesc_, Vec<Dval>),
-  InvalidType(Dval, DType),
+  IncorrectArguments(runtime::FunctionDesc_, Vec<Dval<'a>>),
+  InvalidType(Dval<'a>, DType<'a>),
 }
 
-impl fmt::Display for Error {
+impl<'a> fmt::Display for Error<'a> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       Error::MissingFunction(fun) => {
@@ -27,8 +27,9 @@ impl fmt::Display for Error {
   }
 }
 
-impl std::error::Error for Error {
+impl<'a> std::error::Error for Error<'a> {
   fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-    Some(self)
+    // Some(self)
+    None
   }
 }

--- a/rust-hyper/execution-engine/src/eval.rs
+++ b/rust-hyper/execution-engine/src/eval.rs
@@ -8,14 +8,14 @@ use crate::{
 use im_rc as im;
 use itertools::Itertools;
 use macros::stdlibfn;
-use std::sync::Arc;
+use std::{sync::Arc, borrow::Cow};
 use chttp::ResponseExt;
 
 pub struct ExecState {
   pub caller: Caller,
 }
 
-pub fn run(state: &ExecState, body: Expr) -> Dval {
+pub fn run<'a, 'b>(state: &'b ExecState, body: Expr<'a>) -> Dval<'a> {
   let environment = Environment { functions: stdlib(), };
 
   let st = im::HashMap::new();
@@ -23,7 +23,7 @@ pub fn run(state: &ExecState, body: Expr) -> Dval {
   eval(state, body, st, &environment)
 }
 
-pub fn run_string(state: &ExecState, body: Expr) -> String {
+pub fn run_string<'a>(state: &'a ExecState, body: Expr<'a>) -> String {
   match &*run(state, body) {
     dval::Dval_::DSpecial(dval::Special::Error(_, err)) => {
       format!("Error: {}", err)
@@ -32,14 +32,14 @@ pub fn run_string(state: &ExecState, body: Expr) -> String {
   }
 }
 
-pub fn run_json(state: &ExecState, body: Expr) -> serde_json::Value {
-  (run(state, body)).to_json()
+pub fn run_json<'a, 'b>(state: &'b ExecState, body: Expr<'a>) -> String {
+  serde_json::to_string(&*run(state, body)).unwrap()
 }
 
 fn stdlib() -> StdlibDef {
   #[stdlibfn]
   fn int__toString__0(a: Int) {
-    dstr(&*format!("{}", *a))
+    dstr(Cow::Owned(format!("{}", *a)))
   }
 
   #[stdlibfn]
@@ -90,8 +90,8 @@ fn stdlib() -> StdlibDef {
     let mut response = chttp::get("http://localhost:1025/delay/1").unwrap();
     let text = response.text().unwrap();
     let json : serde_json::Value = serde_json::from_str(&text).unwrap();
-    let result = json["data"].as_str().unwrap();
-    dstr(result)
+    let result = json["data"].as_str().unwrap().to_string();
+    dstr(Cow::Owned(result))
   }
 
   #[stdlibfn]
@@ -103,7 +103,7 @@ fn stdlib() -> StdlibDef {
                  let environment =
                    Environment { functions: stdlib(), };
                  let st =
-                   l_symtable.update(l_vars[0].clone(), dv.clone());
+                   l_symtable.update(l_vars[0], dv.clone());
                  let result = eval(state,
                                    l_body.clone(),
                                    st.clone(),
@@ -136,15 +136,15 @@ fn stdlib() -> StdlibDef {
   fns.into_iter().collect()
 }
 
-fn eval(state: &ExecState,
-        expr: Expr,
-        symtable: SymTable,
-        env: &Environment)
-        -> Dval {
+fn eval<'a, 'b>(state: &'b ExecState,
+        expr: Expr<'a>,
+        symtable: SymTable<'a>,
+        env: &'b Environment)
+        -> Dval<'a> {
   use crate::{dval::*, expr::Expr_::*};
   match &*expr {
     IntLiteral { id: _, val } => dint(val.clone()),
-    StringLiteral { id: _, val } => dstr(val),
+    StringLiteral { id: _, val } => dstr(Cow::Borrowed(val)),
     Blank { id } => {
       dincomplete(&Caller::Code(state.caller.to_tlid(), *id))
     }
@@ -153,11 +153,11 @@ fn eval(state: &ExecState,
           rhs,
           body, } => {
       let rhs = eval(state, rhs.clone(), symtable.clone(), env);
-      let new_symtable = symtable.update(lhs.clone(), rhs);
+      let new_symtable = symtable.update(lhs, rhs);
       eval(state, body.clone(), new_symtable, env)
     }
     Variable { id: _, name } => {
-      symtable.get(name).expect("variable does not exist").clone()
+      symtable.get(*name).expect("variable does not exist").clone()
     }
     Lambda { id: _,
              params,

--- a/rust-hyper/execution-engine/src/eval.rs
+++ b/rust-hyper/execution-engine/src/eval.rs
@@ -154,7 +154,7 @@ fn eval<'a, 'b>(state: &'b ExecState,
           body, } => {
       let rhs = eval(state, rhs, symtable.clone(), env);
       let new_symtable = symtable.update(lhs, rhs);
-      eval(state, body.clone(), new_symtable, env)
+      eval(state, body, new_symtable, env)
     }
     Variable { id: _, name } => {
       symtable.get(*name).expect("variable does not exist").clone()
@@ -168,12 +168,12 @@ fn eval<'a, 'b>(state: &'b ExecState,
          cond,
          then_body,
          else_body, } => {
-      let result = eval(state, cond.clone(), symtable.clone(), env);
+      let result = eval(state, cond, symtable.clone(), env);
       match *result {
         DBool(true) => {
-          eval(state, then_body.clone(), symtable.clone(), env)
+          eval(state, then_body, symtable.clone(), env)
         }
-        DBool(false) => eval(state, else_body.clone(), symtable, env),
+        DBool(false) => eval(state, else_body, symtable, env),
         _ => dcode_error(&state.caller,
                          *id,
                          InvalidType(result, dval::DType::TBool)),
@@ -185,9 +185,9 @@ fn eval<'a, 'b>(state: &'b ExecState,
       match fn_def {
         Option::Some(v) => {
           let lhs =
-            eval(state, lhs.clone(), symtable.clone(), env.clone());
+            eval(state, lhs, symtable.clone(), env.clone());
           let rhs =
-            eval(state, rhs.clone(), symtable.clone(), env.clone());
+            eval(state, rhs, symtable.clone(), env.clone());
           let state = ExecState { caller:
                                     Caller::Code(state.caller
                                                       .to_tlid(),
@@ -210,7 +210,7 @@ fn eval<'a, 'b>(state: &'b ExecState,
           let args: Vec<Dval> =
             args.into_iter()
                 .map(|arg| {
-                  eval(&state, arg.clone(), symtable.clone(), env)
+                  eval(&state, arg, symtable.clone(), env)
                 })
                 .collect();
           let state = ExecState { caller:

--- a/rust-hyper/execution-engine/src/eval.rs
+++ b/rust-hyper/execution-engine/src/eval.rs
@@ -8,7 +8,7 @@ use crate::{
 use im_rc as im;
 use itertools::Itertools;
 use macros::stdlibfn;
-use std::{sync::Arc, borrow::Cow};
+use std::{borrow::Cow, rc::Rc};
 use chttp::ResponseExt;
 
 pub struct ExecState {
@@ -162,7 +162,7 @@ fn eval<'a, 'b>(state: &'b ExecState,
     Lambda { id: _,
              params,
              body, } => {
-      Arc::new(DLambda(symtable, params.clone(), body))
+      Rc::new(DLambda(symtable, params.clone(), body))
     }
     If { id,
          cond,

--- a/rust-hyper/execution-engine/src/eval.rs
+++ b/rust-hyper/execution-engine/src/eval.rs
@@ -36,7 +36,7 @@ pub fn run_json<'a, 'b>(state: &'b ExecState, body: &'a Expr<'a>) -> String {
   serde_json::to_string(&*run(state, body)).unwrap()
 }
 
-fn stdlib() -> StdlibDef {
+fn stdlib() -> StdlibDef<'static> {
   #[stdlibfn]
   fn int__toString__0(a: Int) {
     dstr(Cow::Owned(format!("{}", *a)))

--- a/rust-hyper/execution-engine/src/expr.rs
+++ b/rust-hyper/execution-engine/src/expr.rs
@@ -1,4 +1,3 @@
-use im_rc as im;
 use std::borrow::Cow;
 
 use crate::runtime::*;
@@ -76,11 +75,9 @@ pub fn evar<'a>(name: &'a str) -> Expr<'a> {
                       name: name, }
 }
 
-pub fn elambda<'a>(names: im::Vector<&'a str>, body: Expr<'a>) -> Expr<'a> {
+pub fn elambda<'a>(names: Cow<'a, [&'a str]>, body: Expr<'a>) -> Expr<'a> {
   Lambda { id: gid(),
-                    params: names.iter()
-                                 .map(|&n| n)
-                                 .collect(),
+                    params: names,
                     body: Box::new(body) }
 }
 

--- a/rust-hyper/execution-engine/src/expr.rs
+++ b/rust-hyper/execution-engine/src/expr.rs
@@ -1,5 +1,5 @@
 use im_rc as im;
-use std::sync::Arc;
+use std::{sync::Arc, borrow::Cow};
 
 use crate::runtime::*;
 use ramp;
@@ -15,11 +15,11 @@ pub enum Expr_<'a> {
   FnCall {
     id:   ID,
     name: FunctionDesc_,
-    args: im::Vector<Expr<'a>>,
+    args: Cow<'a, [Expr<'a>]>,
   },
   Lambda {
     id:     ID,
-    params: im::Vector<&'a str>,
+    params: Cow<'a, [&'a str]>,
     body:   Expr<'a>,
   },
   BinOp {
@@ -52,8 +52,6 @@ pub enum Expr_<'a> {
 }
 
 pub type Expr<'a> = Arc<Expr_<'a>>;
-unsafe impl<'a> Send for Expr_<'a> {}
-unsafe impl<'a> Sync for Expr_<'a> {}
 
 use Expr_::*;
 
@@ -119,7 +117,7 @@ pub fn efn<'a>(owner: &'a str,
            module: &'a str,
            name: &'a str,
            version: u32,
-           args: im::Vector<Expr<'a>>)
+           args: Cow<'a, [Expr<'a>]>)
            -> Expr<'a> {
   Arc::new(FnCall { id: gid(),
                     name:
@@ -135,7 +133,7 @@ pub fn efn<'a>(owner: &'a str,
 pub fn esfn<'a>(module: &'a str,
             name: &'a str,
             version: u32,
-            args: im::Vector<Expr<'a>>)
+            args: Cow<'a, [Expr<'a>]>)
             -> Expr<'a> {
   efn("dark", "stdlib", module, name, version, args)
 }

--- a/rust-hyper/execution-engine/src/expr.rs
+++ b/rust-hyper/execution-engine/src/expr.rs
@@ -13,7 +13,7 @@ pub enum Expr<'a> {
   },
   FnCall {
     id:   ID,
-    name: FunctionDesc_,
+    name: FunctionDesc_<'a>,
     args: Vec<Expr<'a>>,
   },
   Lambda {
@@ -24,7 +24,7 @@ pub enum Expr<'a> {
   BinOp {
     id:  ID,
     lhs: Box<Expr<'a>>,
-    op:  FunctionDesc_,
+    op:  FunctionDesc_<'a>,
     rhs: Box<Expr<'a>>,
   },
   If {
@@ -97,10 +97,10 @@ pub fn ebinop<'a>(lhs: Expr<'a>,
   BinOp { id: gid(),
                    lhs: Box::new(lhs),
                    op:
-                     FunctionDesc_::FunctionDesc("dark".to_string(),
-                                                 "stdlib".to_string(),
-                                                 module.to_string(),
-                                                 op.to_string(),
+                     FunctionDesc_::FunctionDesc("dark",
+                                                 "stdlib",
+                                                 module,
+                                                 op,
                                                  version),
                    rhs: Box::new(rhs) }
 }
@@ -118,10 +118,10 @@ pub fn efn<'a>(owner: &'a str,
            -> Expr<'a> {
   FnCall { id: gid(),
                     name:
-                      FunctionDesc_::FunctionDesc(owner.to_string(),
-                                                  package.to_string(),
-                                                  module.to_string(),
-                                                  name.to_string(),
+                      FunctionDesc_::FunctionDesc(owner,
+                                                  package,
+                                                  module,
+                                                  name,
                                                   version),
                     args }
 }

--- a/rust-hyper/execution-engine/src/expr.rs
+++ b/rust-hyper/execution-engine/src/expr.rs
@@ -1,38 +1,38 @@
 use im_rc as im;
-use std::{sync::Arc, borrow::Cow};
+use std::borrow::Cow;
 
 use crate::runtime::*;
 use ramp;
 
 #[derive(Debug)]
-pub enum Expr_<'a> {
+pub enum Expr<'a> {
   Let {
     id:   ID,
     lhs:  &'a str,
-    rhs:  Expr<'a>,
-    body: Expr<'a>,
+    rhs:  Box<Expr<'a>>,
+    body: Box<Expr<'a>>,
   },
   FnCall {
     id:   ID,
     name: FunctionDesc_,
-    args: Cow<'a, [Expr<'a>]>,
+    args: Vec<Expr<'a>>,
   },
   Lambda {
     id:     ID,
     params: Cow<'a, [&'a str]>,
-    body:   Expr<'a>,
+    body:   Box<Expr<'a>>,
   },
   BinOp {
     id:  ID,
-    lhs: Expr<'a>,
+    lhs: Box<Expr<'a>>,
     op:  FunctionDesc_,
-    rhs: Expr<'a>,
+    rhs: Box<Expr<'a>>,
   },
   If {
     id:        ID,
-    cond:      Expr<'a>,
-    then_body: Expr<'a>,
-    else_body: Expr<'a>,
+    cond:      Box<Expr<'a>>,
+    then_body: Box<Expr<'a>>,
+    else_body: Box<Expr<'a>>,
   },
   Variable {
     id:   ID,
@@ -51,44 +51,44 @@ pub enum Expr_<'a> {
   },
 }
 
-pub type Expr<'a> = Arc<Expr_<'a>>;
+// pub type Expr<'a> = Arc<Expr_<'a>>;
 
-use Expr_::*;
+use Expr::*;
 
 pub fn elet<'a>(lhs: &'a str, rhs: Expr<'a>, body: Expr<'a>) -> Expr<'a> {
-  Arc::new(Let { id: gid(),
+  Let { id: gid(),
                  lhs,
-                 rhs,
-                 body })
+                 rhs: Box::new(rhs),
+                 body: Box::new(body) }
 }
 
 pub fn estr<'a>(val: &'a str) -> Expr<'a> {
-  Arc::new(StringLiteral { id:  gid(),
-                           val: val, })
+  StringLiteral { id:  gid(),
+                           val: val, }
 }
 pub fn eint<'a>(val: i64) -> Expr<'a> {
-  Arc::new(IntLiteral { id:  gid(),
-                        val: ramp::Int::from(val), })
+  IntLiteral { id:  gid(),
+                        val: ramp::Int::from(val), }
 }
 
 pub fn evar<'a>(name: &'a str) -> Expr<'a> {
-  Arc::new(Variable { id:   gid(),
-                      name: name, })
+  Variable { id:   gid(),
+                      name: name, }
 }
 
 pub fn elambda<'a>(names: im::Vector<&'a str>, body: Expr<'a>) -> Expr<'a> {
-  Arc::new(Lambda { id: gid(),
+  Lambda { id: gid(),
                     params: names.iter()
                                  .map(|&n| n)
                                  .collect(),
-                    body })
+                    body: Box::new(body) }
 }
 
 pub fn eif<'a>(cond: Expr<'a>, then_body: Expr<'a>, else_body: Expr<'a>) -> Expr<'a> {
-  Arc::new(If { id: gid(),
-                cond,
-                then_body,
-                else_body })
+  If { id: gid(),
+                cond: Box::new(cond),
+                then_body: Box::new(then_body),
+                else_body: Box::new(else_body) }
 }
 
 pub fn ebinop<'a>(lhs: Expr<'a>,
@@ -97,19 +97,19 @@ pub fn ebinop<'a>(lhs: Expr<'a>,
               version: u32,
               rhs: Expr<'a>)
               -> Expr<'a> {
-  Arc::new(BinOp { id: gid(),
-                   lhs,
+  BinOp { id: gid(),
+                   lhs: Box::new(lhs),
                    op:
                      FunctionDesc_::FunctionDesc("dark".to_string(),
                                                  "stdlib".to_string(),
                                                  module.to_string(),
                                                  op.to_string(),
                                                  version),
-                   rhs })
+                   rhs: Box::new(rhs) }
 }
 
 pub fn eblank<'a>() -> Expr<'a> {
-  Arc::new(Blank { id: gid() })
+  Blank { id: gid() }
 }
 
 pub fn efn<'a>(owner: &'a str,
@@ -117,23 +117,23 @@ pub fn efn<'a>(owner: &'a str,
            module: &'a str,
            name: &'a str,
            version: u32,
-           args: Cow<'a, [Expr<'a>]>)
+           args: Vec<Expr<'a>>)
            -> Expr<'a> {
-  Arc::new(FnCall { id: gid(),
+  FnCall { id: gid(),
                     name:
                       FunctionDesc_::FunctionDesc(owner.to_string(),
                                                   package.to_string(),
                                                   module.to_string(),
                                                   name.to_string(),
                                                   version),
-                    args })
+                    args }
 }
 
 // Stdlib function
 pub fn esfn<'a>(module: &'a str,
             name: &'a str,
             version: u32,
-            args: Cow<'a, [Expr<'a>]>)
+            args: Vec<Expr<'a>>)
             -> Expr<'a> {
   efn("dark", "stdlib", module, name, version, args)
 }

--- a/rust-hyper/execution-engine/src/lib.rs
+++ b/rust-hyper/execution-engine/src/lib.rs
@@ -8,7 +8,7 @@ macro_rules! ivec {
       im_rc::Vector::new()
   );
   ($($x:expr),+ $(,)?) => (
-      im_rc::Vector::from(<[_]>::into_vec(box [$($x),+]))
+      std::borrow::Cow::Owned(im_rc::Vector::from(<[_]>::into_vec(box [$($x),+])))
   );
 }
 

--- a/rust-hyper/execution-engine/src/op.rs
+++ b/rust-hyper/execution-engine/src/op.rs
@@ -1,11 +1,3 @@
-#[cfg(test)]
-mod tests {
-  #[test]
-  fn can_create_hello_world() {
-    assert_eq!(process([Op::]), estr("hello_world!"));
-  }
-}
-
 use crate::expr;
 
 pub enum Op {

--- a/rust-hyper/execution-engine/src/runtime.rs
+++ b/rust-hyper/execution-engine/src/runtime.rs
@@ -1,6 +1,6 @@
 use crate::dval::Dval;
 use im_rc as im;
-use std::{fmt, sync::Arc};
+use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum FunctionDesc_ {
@@ -36,7 +36,7 @@ impl Caller {
 }
 
 pub type FuncSig =
-  Arc<dyn for<'s, 'a> Fn(&'s crate::eval::ExecState, Vec<Dval<'a>>) -> Dval<'a>>;
+  Box<dyn for<'s, 'a> Fn(&'s crate::eval::ExecState, Vec<Dval<'a>>) -> Dval<'a>>;
 
 pub type SymTable<'a> = im::HashMap<&'a str, Dval<'a>>;
 

--- a/rust-hyper/execution-engine/src/runtime.rs
+++ b/rust-hyper/execution-engine/src/runtime.rs
@@ -3,11 +3,11 @@ use im_rc as im;
 use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum FunctionDesc_ {
-  FunctionDesc(String, String, String, String, u32),
+pub enum FunctionDesc_<'a> {
+  FunctionDesc(&'a str, &'a str, &'a str, &'a str, u32),
 }
 
-impl fmt::Display for FunctionDesc_ {
+impl<'a> fmt::Display for FunctionDesc_<'a> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let FunctionDesc_::FunctionDesc(owner,
                                     package,
@@ -68,9 +68,9 @@ impl fmt::Debug for StdlibFunction {
   }
 }
 
-pub type StdlibDef =
-  std::collections::HashMap<FunctionDesc_, StdlibFunction>;
+pub type StdlibDef<'a> =
+  std::collections::HashMap<&'a FunctionDesc_<'a>, StdlibFunction>;
 
-pub struct Environment {
-  pub functions: StdlibDef,
+pub struct Environment<'a> {
+  pub functions: StdlibDef<'a>,
 }

--- a/rust-hyper/execution-engine/src/runtime.rs
+++ b/rust-hyper/execution-engine/src/runtime.rs
@@ -36,9 +36,9 @@ impl Caller {
 }
 
 pub type FuncSig =
-  Arc<dyn Fn(&crate::eval::ExecState, Vec<Dval>) -> Dval>;
+  Arc<dyn for<'s, 'a> Fn(&'s crate::eval::ExecState, Vec<Dval<'a>>) -> Dval<'a>>;
 
-pub type SymTable = im::HashMap<String, Dval>;
+pub type SymTable<'a> = im::HashMap<&'a str, Dval<'a>>;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Copy)]
 pub enum TLID {

--- a/rust-hyper/macros/lib.rs
+++ b/rust-hyper/macros/lib.rs
@@ -226,7 +226,7 @@ pub fn stdlibfn(_attr: TokenStream,
            f:
              {
                Arc::new(
-                 move |state : &ExecState, args : Vec<Dval>| { {
+                 move |state : &ExecState, args : Vec<Dval<'_>>| { {
                    match args.iter().map(|v| &(**v)).collect::<Vec<_>>().as_slice() {
                      [ #argument_patterns ] => #body,
                      _ => {

--- a/rust-hyper/macros/lib.rs
+++ b/rust-hyper/macros/lib.rs
@@ -225,7 +225,7 @@ pub fn stdlibfn(_attr: TokenStream,
          StdlibFunction {
            f:
              {
-               Arc::new(
+               Box::new(
                  move |state : &ExecState, args : Vec<Dval<'_>>| { {
                    match args.iter().map(|v| &(**v)).collect::<Vec<_>>().as_slice() {
                      [ #argument_patterns ] => #body,
@@ -233,7 +233,7 @@ pub fn stdlibfn(_attr: TokenStream,
                        for arg in args.clone() {
                          if (arg).is_special() { return arg.clone ()}
                        }
-                       Arc::new(Dval_::DSpecial((Special::Error(state.caller, IncorrectArguments(fn_name2.clone(), args)))))
+                       std::rc::Rc::new(Dval_::DSpecial((Special::Error(state.caller, IncorrectArguments(fn_name2.clone(), args)))))
                      }}}})},
                     })}
 

--- a/rust-hyper/macros/lib.rs
+++ b/rust-hyper/macros/lib.rs
@@ -212,15 +212,14 @@ pub fn stdlibfn(_attr: TokenStream,
 
 
     #[allow(non_snake_case)]
-    fn #fn_name() -> (FunctionDesc_, StdlibFunction) {
-        let fn_name = FunctionDesc_::FunctionDesc(
-            #owner.to_string(),
-            #package.to_string(),
-            #module.to_string(),
-            #function.to_string(),
+    fn #fn_name() -> (&'static FunctionDesc_<'static>, StdlibFunction) {
+        static fn_name: &'static FunctionDesc_<'static> = &FunctionDesc_::FunctionDesc(
+            #owner,
+            #package,
+            #module,
+            #function,
             #version,
         );
-        let fn_name2 = fn_name.clone();
           (fn_name,
          StdlibFunction {
            f:
@@ -233,7 +232,7 @@ pub fn stdlibfn(_attr: TokenStream,
                        for arg in args.clone() {
                          if (arg).is_special() { return arg.clone ()}
                        }
-                       std::rc::Rc::new(Dval_::DSpecial((Special::Error(state.caller, IncorrectArguments(fn_name2.clone(), args)))))
+                       std::rc::Rc::new(Dval_::DSpecial((Special::Error(state.caller, IncorrectArguments(fn_name, args)))))
                      }}}})},
                     })}
 


### PR DESCRIPTION
Notes: 
- This will remove source information from errors due to lifetime issues
- `Arc`s replaced by `Rc`s. With more work, It should be possible to reduce `Rc` usage as well and replace with either references or with `Box`s
- implemented serde serializer instead of converting to DOM and then serializing.