### PR TITLE
C# Sync benchmark

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,115 @@
+#https://www.edwardthomson.com/blog/git_for_windows_line_endings.html
+*   text=auto
+
+# https://github.com/alexkaratarakis/gitattributes
+
+*.sh        text eol=lf
+*.bash      text eol=lf
+
+*.bat       text eol=crlf
+*.cmd       text eol=crlf
+*.ps1       text eol=crlf
+*.rc        text eol=crlf
+*.sln       text eol=crlf
+*.csproj    text eol=crlf
+*.vbproj    text eol=crlf
+*.vcxproj   text eol=crlf
+*.vcproj    text eol=crlf
+*.dbproj    text eol=crlf
+*.fsproj    text eol=crlf
+*.lsproj    text eol=crlf
+*.wixproj   text eol=crlf
+*.modelproj text eol=crlf
+*.sqlproj   text eol=crlf
+*.wmaproj   text eol=crlf
+*.xproj     text eol=crlf
+*.props     text eol=crlf
+*.filters   text eol=crlf
+*.vcxitems  text eol=crlf
+
+*.cs        text diff=csharp
+*.c         text diff=c
+*.h         text diff=c
+*.cpp       text diff=cpp
+*.m         text eol=lf diff=objc
+*.swift     text eol=lf diff=swift
+
+*.md        text
+*.csv       text
+*.tab       text
+*.tsv       text
+*.txt       text
+*.sql       text
+*.svg       text
+*.css       text
+*.htm       text
+*.ini       text
+*.js        text
+*.py        text
+*.conf      text
+*.config    text
+*.json      text
+*.toml      text
+*.xml       text
+*.yaml      text
+*.yml       text
+
+*.pbxproj   binary -merge=union
+
+*.pfx       binary
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.tif       binary
+*.tiff      binary
+*.ico       binary
+*.psb       binary
+*.psd       binary
+*.bmp       binary
+*.pdf       binary
+*.webp      binary
+*.m4a       binary
+*.mid       binary
+*.midi      binary
+*.mp3       binary
+*.ogg       binary
+*.3gpp      binary
+*.3gp       binary
+*.as        binary
+*.asf       binary
+*.asx       binary
+*.fla       binary
+*.flv       binary
+*.m4v       binary
+*.mng       binary
+*.mov       binary
+*.mp4       binary
+*.mpeg      binary
+*.mpg       binary
+*.ogv       binary
+*.swf       binary
+*.webm      binary
+*.ttf       binary
+*.eot       binary
+*.otf       binary
+*.woff      binary
+*.woff2     binary
+*.7z        binary
+*.gz        binary
+*.tar       binary
+*.zip       binary
+*.gch       binary
+*.pch       binary
+*.slo       binary
+*.lo        binary
+*.o         binary
+*.obj       binary
+*.so        binary
+*.dylib     binary
+*.dll       binary
+*.a         binary
+*.lib       binary
+*.exe       binary
+*.out       binary
+*.app       binary

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,15 @@
 logs/*.log
 fsharp*/**/bin
 fsharp*/**/obj
+
+csharp*/**/bin
+csharp*/**/obj
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Visual Studio cache/options directory
+.vs/

--- a/csharp/sync/Interpreter.cs
+++ b/csharp/sync/Interpreter.cs
@@ -270,9 +270,8 @@ namespace sync
                     Name: FnDesc.StdFnDesc("Int", "range", 0),
                     Parameters: new[]
                     {
-                        // TODO: these param do not seem right for a range? Copy pase error?
-                        new Param("list", new TList(new TVariable("a")), "The list to be operated on"),
-                        new Param("fn", new TFn(new[] { new TVariable("a") }, new TVariable("b")), "Function to be called on each member"),
+                        new Param("lowerBound", new TInt(), "Range lower bound (inclusive)"),
+                        new Param("upperBound", new TInt(), "Range upper bound (inclusive)"),
                     },
                     ReturnVal: new RetVal(new TList(new TInt()), "List of ints between lowerBound and upperBound"),
                     Fn: (env, args) =>
@@ -280,7 +279,7 @@ namespace sync
                         if (args.Count == 2 && args[0] is DInt lower && args[1] is DInt upper)
                         {
                             // TODO: the range should support BigInteger properly
-                            var range = Enumerable.Range((int)lower.Value, (int)upper.Value).Select(x => new DInt(x));
+                            var range = Enumerable.Range((int)lower.Value, (int)(upper.Value - lower.Value + 1)).Select(x => new DInt(x));
                             return new Ok<DVal>(new DList(range.ToList()));
                         }
                         else

--- a/csharp/sync/Interpreter.cs
+++ b/csharp/sync/Interpreter.cs
@@ -1,0 +1,192 @@
+﻿using System.Numerics;
+using System.Text.Json.Nodes;
+
+namespace sync
+{
+    public record FnDesc(
+        string Owner,
+        string Package,
+        string Module,
+        string Function,
+        int Version)
+    {
+        public static FnDesc StdFnDesc(string module, string function, int version)
+            => new("dark", "stdlib", module, function, version);
+    }
+
+    public enum ExpType
+    {
+        Unknown,
+        EInt,
+        EString,
+        ELet,
+        EVariable,
+        EFnCall,
+        EBinOp,
+        ELambda,
+        EIf,
+    }
+
+    public abstract record Expr(ExpType Type)
+    {
+        public static EFnCall Sfn(string module, string function, int version, IReadOnlyList<Expr> args)
+            => new(new FnDesc("dark", "stdlib", module, function, version), args);
+
+        public static EBinOp BinOp(Expr arg1, string module, string function, int version, Expr arg2)
+            => new(arg1, new FnDesc("dark", "stdlib", module, function, version), arg2);
+    }
+    public record EInt(BigInteger Value) : Expr(ExpType.EInt);
+    public record EString(string Value) : Expr(ExpType.EString);
+    public record ELet(string Lhs, Expr Rhs, Expr Body) : Expr(ExpType.ELet);
+    public record EVariable(string Name) : Expr(ExpType.EVariable);
+    public record EFnCall(FnDesc FnDesc, IReadOnlyList<Expr> Args) : Expr(ExpType.EFnCall);
+    public record EBinOp(Expr Arg1, FnDesc FnDesc, Expr Arg2) : Expr(ExpType.EBinOp);
+    public record ELambda(IReadOnlyList<string> Vars, Expr Expr) : Expr(ExpType.ELambda);
+    public record EIf(Expr Cond, Expr ThenBody, Expr ElseBody) : Expr(ExpType.EIf);
+
+    public enum DValType
+    {
+        Unknown,
+        DInt,
+        DString,
+        DSpecial,
+        DList,
+        DBool,
+        DLambda,
+    }
+
+    public abstract record DVal(DValType Type)
+    {
+        public bool IsSpecial => Type == DValType.DSpecial;
+
+        public DVal ToDList(IReadOnlyList<DVal> list)
+            => list.FirstOrDefault(x => x.IsSpecial, new DList(list));
+
+        public JsonNode ToJson()
+            => this switch
+            {
+                DInt i => JsonValue.Create(i.Value)!,
+                DString str => JsonValue.Create(str.Value)!,
+                DList l => new JsonArray(l.Values.Select(x => x.ToJson()).ToArray())!,
+                DBool b => JsonValue.Create(b.Value)!,
+                DLambda _ => JsonValue.Create<string>(null)!, // TODO: should this just be "null"?
+                DSpecial s when s.Value is DError e =>
+                    new JsonObject(new[] { KeyValuePair.Create("error", (JsonNode?)JsonValue.Create(e.ToString())) }),
+                _ => throw new InvalidOperationException(),
+            };
+
+        public static DVal Err(RuntimeError e) => new DSpecial(new DError(e));
+    }
+    public record DInt(BigInteger Value) : DVal(DValType.DInt);
+    public record DString(string Value) : DVal(DValType.DString);
+    public record DSpecial(Special Value) : DVal(DValType.DSpecial);
+    public record DList(IReadOnlyList<DVal> Values) : DVal(DValType.DList);
+    public record DBool(bool Value) : DVal(DValType.DBool);
+    public record DLambda(IReadOnlyDictionary<string, DVal> Symtable, IReadOnlyList<string> Vars, Expr Expr) : DVal(DValType.DLambda);
+
+    public static class Symtable
+    {
+        public static IReadOnlyDictionary<string, DVal> Empty => new Dictionary<string, DVal>();
+        public static DVal Get(this IReadOnlyDictionary<string, DVal> st, string name)
+            => st.TryGetValue(name, out var value) ? value : DVal.Err(new ErrUndefinedVariable(name));
+    }
+
+    public enum DTypeType
+    {
+        Unknown,
+        TString,
+        TInt,
+        TBool,
+        TList,
+        TVariable,
+        TFn,
+    }
+
+    public abstract record DType(DTypeType Type);
+    public record TString() : DType(DTypeType.TString);
+    public record TInt() : DType(DTypeType.TInt);
+    public record TBool() : DType(DTypeType.TBool);
+    public record TList(DType ValuesType) : DType(DTypeType.TList);
+    public record TVariable(string Name) : DType(DTypeType.TVariable);
+    public record TFn(IReadOnlyList<DType> ArgTypes, DType ReturnType) : DType(DTypeType.TFn);
+
+    public record Param(string Name, DType Type, string Doc);
+
+    public enum RuntimeErrorType
+    {
+        Unknown,
+        NotAFunction,
+        CondWithNonBool,
+        FnCalledWithWrongTypes,
+        UndefinedVariable,
+    }
+
+    public abstract record RuntimeError(RuntimeErrorType Type);
+    public record ErrNotAFunction(FnDesc FnDesc) : RuntimeError(RuntimeErrorType.NotAFunction);
+    public record ErrCondWithNonBool(DVal Cond) : RuntimeError(RuntimeErrorType.CondWithNonBool);
+    public record ErrFnCalledWithWrongTypes(FnDesc FnDesc, IReadOnlyList<DVal> Values, IReadOnlyList<Param> Params) : RuntimeError(RuntimeErrorType.FnCalledWithWrongTypes);
+    public record ErrUndefinedVariable(string Name) : RuntimeError(RuntimeErrorType.UndefinedVariable);
+
+    public enum SpecialType
+    {
+        Unknown,
+        DError,
+    }
+
+    public abstract record Special(SpecialType Type);
+    public record DError(RuntimeError Error) : Special(SpecialType.DError);
+
+    public record RetVal(DType Type, string Doc);
+
+    public record Environment(IReadOnlyDictionary<FnDesc, BuiltInFn> Functions);
+
+    public abstract record Result<T>
+    {
+        protected Result() { }
+    }
+    public record Ok<T>(T Value) : Result<T>;
+    /// <summary>
+    /// No Error arg because we currently don't need it.
+    /// </summary>
+    public record Error<T>() : Result<T>;
+
+    public record BuiltInFn(
+        string Name,
+        IReadOnlyList<Param> Parameters,
+        RetVal ReturnVal,
+        Func<Environment, IReadOnlyList<DVal>, Result<DVal>> Fn);
+
+    public static class Interpreter
+    {
+        public static readonly Expr FizzBuzz =
+            new ELet(
+                "range",
+                Expr.Sfn("Int", "range", 0, new[] { new EInt(1), new EInt(100) }),
+                Expr.Sfn(
+                    "List",
+                    "map",
+                    0,
+                    new Expr[]
+                    {
+                        new EVariable("range"),
+                        new ELambda(
+                            new[] { "i" },
+                            new EIf(
+                                Expr.BinOp(Expr.BinOp(new EVariable("i"), "Int", "%", 0, new EInt(15)),"Int", "==", 0, new EInt(0)),
+                                new EString("fizzbuzz"),
+                                new EIf(
+                                    Expr.BinOp(Expr.BinOp(new EVariable("i"), "Int", "%", 0, new EInt(5)), "Int", "==", 0, new EInt(0)),
+                                    new EString("buzz"),
+                                    new EIf(
+                                        Expr.BinOp(Expr.BinOp(new EVariable("i"), "Int", "%", 0, new EInt(3)), "Int", "==", 0, new EInt(0)),
+                                        new EString("fizz"),
+                                        Expr.Sfn("Int", "toString", 0, new [] { new EVariable("i") })
+                                    )
+                                )
+                            )
+                        )
+                    }
+                )
+            );
+    }
+}

--- a/csharp/sync/Program.cs
+++ b/csharp/sync/Program.cs
@@ -2,36 +2,8 @@ using sync;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-
 var app = builder.Build();
 
-//System.Linq.Expressions.BinaryExpression
-//var x = new Exp { Type = ExpType.EString };
+app.MapGet("/fizzbuzz", () => Interpreter.RunJson(Interpreter.FizzBuzz));
 
-// Configure the HTTP request pipeline.
-
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast = Enumerable.Range(1, 5).Select(index =>
-       new WeatherForecast
-       (
-           DateTime.Now.AddDays(index),
-           Random.Shared.Next(-20, 55),
-           summaries[Random.Shared.Next(summaries.Length)]
-       ))
-        .ToArray();
-    return forecast;
-});
-
-app.Run();
-
-internal record WeatherForecast(DateTime Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}
+app.Run("http://127.0.0.1:4000");

--- a/csharp/sync/Program.cs
+++ b/csharp/sync/Program.cs
@@ -1,0 +1,37 @@
+using sync;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+var app = builder.Build();
+
+//System.Linq.Expressions.BinaryExpression
+//var x = new Exp { Type = ExpType.EString };
+
+// Configure the HTTP request pipeline.
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+       new WeatherForecast
+       (
+           DateTime.Now.AddDays(index),
+           Random.Shared.Next(-20, 55),
+           summaries[Random.Shared.Next(summaries.Length)]
+       ))
+        .ToArray();
+    return forecast;
+});
+
+app.Run();
+
+internal record WeatherForecast(DateTime Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/csharp/sync/Properties/launchSettings.json
+++ b/csharp/sync/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:7530",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "sync": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "http://localhost:5030",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/csharp/sync/appsettings.Development.json
+++ b/csharp/sync/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/csharp/sync/appsettings.json
+++ b/csharp/sync/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/csharp/sync/sync.csproj
+++ b/csharp/sync/sync.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/csharp/sync/sync.sln
+++ b/csharp/sync/sync.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "sync", "sync.csproj", "{3740DA2F-0B9D-48D5-9A9E-E15F73161428}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3740DA2F-0B9D-48D5-9A9E-E15F73161428}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3740DA2F-0B9D-48D5-9A9E-E15F73161428}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3740DA2F-0B9D-48D5-9A9E-E15F73161428}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3740DA2F-0B9D-48D5-9A9E-E15F73161428}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2DCDBC08-697C-4DB5-91C0-EDD0B91C1050}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Hello,

I manually translated the F# sync benchmark to C#.

It seems to be working (the fizzbuzz endpoint works), but I didn't manage to run the actual `measure.py` benchmark.
(I only have WSL on Windows, and the script returns after `Starting entire benchmark` without more information. I did install `wrk` and it is available on the PATH).

The translation was fairly straightforward. The only thing I'm not satisfied with is the symbol table implementation: I used a normal `Dictionary<,>` accessed through the `IReadOnlyDictionary<,>` interface, so I have to clone it every time something needs to be added.
I'm not sure how to do better. Maybe simply using the F# `Map` type would be enough...
(Or there is another trick that would be more idiomatic in C#? I don't have any experience writing interpreters... :) )

---

With this, I'm mainly interested in a comparison between C# and F# performance.  
I create this PR as a base if you are interested in going further (I might add an async/await implementation then).  
If not, I won't mind if you don't want to merge it.